### PR TITLE
Replace around_filter (💀 in Rails 5.1) with around_action

### DIFF
--- a/lib/gtfs_engine/concerns/controllers/gtfs.rb
+++ b/lib/gtfs_engine/concerns/controllers/gtfs.rb
@@ -20,7 +20,7 @@ module GtfsEngine::Concerns::Controllers::Gtfs
 
 
   included do
-    around_filter :gtfs_cache, only: [:index, :show]
+    around_action :gtfs_cache, only: [:index, :show]
 
     rescue_from GtfsEngine::UnknownFilters,     with: :unknown_filter
     rescue_from ActiveRecord::StatementInvalid, with: :statement_invalid


### PR DESCRIPTION
👋 

### Issue

I just bumped my app from Rails 4 to Rails 5, and the app ran fine in development mode, using GTFS data and everything. However, with `RAILS_ENV=production`, I get (full stack trace at the end):

`rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/lib/gtfs_engine/concerns/controllers/gtfs.rb:23:in `block in <module:Gtfs>': undefined method `around_filter' for GtfsEngine::AgenciesController:Class (NoMethodError)`

### Cause

That happens because Rails 5.1 [dropped](https://guides.rubyonrails.org/5_1_release_notes.html) (specifically with this [commit](https://github.com/rails/rails/commit/d7be30e8babf5e37a891522869e7b0191b79b757)) all the `_filter` methods, which are deprecated in favour of `*_action` ones [since Rails 4.2](https://guides.rubyonrails.org/4_2_release_notes.html#action-pack-notable-changes).

### Fix

I confirmed that replacing `around_filter` with `around_action` directly in my server allows the app to start in production mode, so I'm PR-ing that change only.

I could not really test the routes (my app does not use them - in fact, I should likely be using the gem directly 😄), but it seems to be the only issue for upgrading (from a cursory look), so here it is!  

---

Full stack trace:

```
$ bin/rails server
=> Booting Puma
=> Rails 5.2.4.2 application starting in production
=> Run `rails server -h` for more startup options
Exiting
Traceback (most recent call last):
	67: from bin/rails:4:in `<main>'
	66: from bin/rails:4:in `require'
	65: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands.rb:18:in `<top (required)>'
	64: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/command.rb:46:in `invoke'
	63: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/command/base.rb:69:in `perform'
	62: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	61: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	60: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	59: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands/server/server_command.rb:142:in `perform'
	58: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands/server/server_command.rb:142:in `tap'
	57: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands/server/server_command.rb:147:in `block in perform'
	56: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands/server/server_command.rb:53:in `start'
	55: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:311:in `start'
	54: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:379:in `handle_profiling'
	53: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:312:in `block in start'
	52: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:422:in `wrapped_app'
	51: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/commands/server/server_command.rb:27:in `app'
	50: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:249:in `app'
	49: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	48: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/builder.rb:66:in `parse_file'
	47: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/builder.rb:105:in `load_file'
	46: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/builder.rb:116:in `new_from_string'
	45: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rack-2.2.2/lib/rack/builder.rb:116:in `eval'
	44: from config.ru:3:in `block in <main>'
	43: from config.ru:3:in `require'
	42: from /home/chester/cruzalinhas/source/config/environment.rb:5:in `<top (required)>'
	41: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/application.rb:361:in `initialize!'
	40: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/initializable.rb:60:in `run_initializers'
	39: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:205:in `tsort_each'
	38: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:226:in `tsort_each'
	37: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
	36: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `call'
	35: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `each'
	34: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
	33: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
	32: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	31: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
	30: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/initializable.rb:61:in `block in run_initializers'
	29: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/initializable.rb:32:in `run'
	28: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/initializable.rb:32:in `instance_exec'
	27: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/application/finisher.rb:69:in `block in <module:Finisher>'
	26: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/application/finisher.rb:69:in `each'
	25: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:356:in `eager_load!'
	24: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:475:in `eager_load!'
	23: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:475:in `each'
	22: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:477:in `block in eager_load!'
	21: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:477:in `each'
	20: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/railties-5.2.4.2/lib/rails/engine.rb:478:in `block (2 levels) in eager_load!'
	19: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:246:in `require_dependency'
	18: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:334:in `depend_on'
	17: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:356:in `require_or_load'
	16: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:37:in `load_interlock'
	15: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies/interlock.rb:13:in `loading'
	14: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
	13: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
	12: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:37:in `block in load_interlock'
	11: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:378:in `block in require_or_load'
	10: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `require'
	 9: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:257:in `load_dependency'
	 8: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `block in require'
	 7: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `require'
	 6: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/app/controllers/gtfs_engine/agencies_controller.rb:15:in `<top (required)>'
	 5: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/app/controllers/gtfs_engine/agencies_controller.rb:16:in `<module:GtfsEngine>'
	 4: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/app/controllers/gtfs_engine/agencies_controller.rb:17:in `<class:AgenciesController>'
	 3: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/app/controllers/gtfs_engine/agencies_controller.rb:17:in `include'
	 2: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/concern.rb:122:in `append_features'
	 1: from /home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activesupport-5.2.4.2/lib/active_support/concern.rb:122:in `class_eval'
/home/chester/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/gtfs_engine-1.5.3/lib/gtfs_engine/concerns/controllers/gtfs.rb:23:in `block in <module:Gtfs>': undefined method `around_filter' for GtfsEngine::AgenciesController:Class (NoMethodError)
Did you mean?  around_action
```